### PR TITLE
fix node env variable INIT_CMD issue on windows

### DIFF
--- a/postinstall.js
+++ b/postinstall.js
@@ -1,10 +1,12 @@
 const fs = require('fs');
 const path = require('path');
 
+const cwd = process.env.INIT_CWD || process.cwd();
+
 /**
  * husky.
  */
-const huskyConfigPath = path.join(process.env.INIT_CWD, 'husky.config.js');
+const huskyConfigPath = path.join(cwd, 'husky.config.js');
 
 if (!fs.existsSync(huskyConfigPath)) {
     fs.writeFileSync(
@@ -17,7 +19,7 @@ if (!fs.existsSync(huskyConfigPath)) {
  * lint-staged.
  */
 const lintStagedConfigPath = path.join(
-    process.env.INIT_CWD,
+    cwd,
     'lint-staged.config.js'
 );
 
@@ -31,7 +33,7 @@ if (!fs.existsSync(lintStagedConfigPath)) {
 /**
  * prettier.
  */
-const prettierConfigPath = path.join(process.env.INIT_CWD, '.prettierrc.js');
+const prettierConfigPath = path.join(cwd, '.prettierrc.js');
 
 if (!fs.existsSync(prettierConfigPath)) {
     fs.writeFileSync(


### PR DESCRIPTION
on windows 

process.env.INIT_CWD

throw new ERR_INVALID_ARG_TYPE(name, 'string', value);

when passed to 
path.join(process.env.INIT_CWD, 'husky.config.js');

so using
process.cwd()

as a fallback for windows

slack discussion ref: https://conversionxl.slack.com/archives/C0G52K19U/p1606730153003000