### PR TITLE
refactor: customize commitlint rules

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,26 @@
-module.exports = { extends: ['@commitlint/config-conventional'] };
+// @see https://github.com/conventional-changelog/commitlint/blob/v12.0.1/@commitlint/config-conventional/index.js
+module.exports = {
+    extends: ['@commitlint/config-conventional'],
+
+    rules: {
+        'body-max-line-length': [1, 'always', 100],
+        'header-max-length': [1, 'always', 100],
+        'scope-case': [2, 'never', ['kebab-case', 'snake-case']],
+        'subject-case': [
+            2,
+            'never',
+            [
+                'upper-case',
+                'camel-case',
+                'kebab-case',
+                'pascal-case',
+                'snake-case',
+            ],
+        ],
+        'type-enum': [
+            2,
+            'always',
+            ['chore', 'docs', 'feat', 'fix', 'refactor', 'style', 'test'],
+        ],
+    },
+};


### PR DESCRIPTION
Adjust commitlint rules to follow [semantic commit messages ](https://sparkbox.com/foundry/semantic_commit_messages) and good practices.

Base commitlint config `@commitlint/config-conventional` follows https://www.conventionalcommits.org/en/v1.0.0/ but what we do is slightly different.