### PR TITLE
refactor(commitlint): change `scope-case` rules

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -16,17 +16,7 @@ module.exports = {
                 'start-case',
             ],
         ],
-        'subject-case': [
-            2,
-            'never',
-            [
-                'upper-case',
-                'camel-case',
-                'kebab-case',
-                'pascal-case',
-                'snake-case',
-            ],
-        ],
+        'subject-case': [2, 'never', ['start-case', 'pascal-case', 'upper-case']],
         'type-enum': [
             2,
             'always',

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -5,7 +5,17 @@ module.exports = {
     rules: {
         'body-max-line-length': [1, 'always', 100],
         'header-max-length': [1, 'always', 100],
-        'scope-case': [2, 'never', ['kebab-case', 'snake-case']],
+        'scope-case': [
+            2,
+            'always',
+            [
+                'lower-case',
+                'kebab-case',
+                'pascal-case',
+                'sentence-case',
+                'start-case',
+            ],
+        ],
         'subject-case': [
             2,
             'never',


### PR DESCRIPTION
Introduced in #4 

Discussion https://cxlworld.slack.com/archives/C01JABH8AHX/p1645522633448099

Using `never` for `kebab-case`, `snake-case` causes errors for lowercase, one word scopes, eg. `composer`, `phpcs` which we use a lot. `always` rules seem to be better idea.